### PR TITLE
refactor(project): Delay creation from run function instead of factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netcentric/component-loader",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netcentric/component-loader",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@netcentric/eslint-config": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netcentric/component-loader",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netcentric/component-loader",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@netcentric/eslint-config": "^1.0.0",

--- a/src/factory.js
+++ b/src/factory.js
@@ -18,46 +18,16 @@ const getComponent = (name) => {
  * Factory by a component name and node
  * Removed this feature from run.js function into its own function for separate use
  */
-export const factory = (name, element, initAttr, lazyAttr) => {
+export const factory = (name, element, initAttr) => {
   // if there is a component available with the name
   const component = getComponent(name);
-  const isLazy = element.getAttribute(lazyAttr) === 'lazy';
 
-  if (!component) {
-    // no component was found
-    deferredComponents[name] = deferredComponents[name] || [];
-    deferredComponents[name].push({ element, initAttr, lazyAttr });
-    // eslint-disable-next-line no-console
-    return console.warn(`Deferring initialisation of Component because factory cannot find a class for "${name}"`);
-  }
-
-  if (!instances[name]) {
-    instances[name] = [];
-  }
-  // create a unique ID for the component + node
-  element.uuid = uuid();
-
-  if (isLazy) {
-    const observerSettings = { rootMargin: '50px 0px', threshold: 0.01 };
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.intersectionRatio > 0) {
-          observer.unobserve(element);
-          // add to the active collection using a unique ID
-          instances[name].push(
-            create(
-              component, // Component Class
-              name, // Component Name
-              element, // Node
-              initAttr // params to find components
-            )
-          );
-        }
-      });
-    }, observerSettings);
-
-    observer.observe(element);
-  } else {
+  if (component) {
+    if (!instances[name]) {
+      instances[name] = [];
+    }
+    // create a unique ID for the component + node
+    element.uuid = uuid();
     // add to the active collection using a unique ID
     instances[name].push(
       create(
@@ -67,7 +37,11 @@ export const factory = (name, element, initAttr, lazyAttr) => {
         initAttr // params to find components
       )
     );
+    return null;
   }
-
-  return null;
+  // no component was found
+  deferredComponents[name] = deferredComponents[name] || [];
+  deferredComponents[name].push({ element, initAttr });
+  // eslint-disable-next-line no-console
+  return console.warn(`Deferring initialisation of Component because factory cannot find a class for "${name}"`);
 };

--- a/src/run.js
+++ b/src/run.js
@@ -16,8 +16,24 @@ export const run = (element = window.document, initAttr = 'data-nc', lazyAttr = 
         node.initialized = true;
         // get the component that needs, will load by attribute
         const componentNames = node.getAttribute(initAttr).split(',');
-        componentNames.forEach((name) =>
-          factory(name, node, initAttr, lazyAttr));
+        componentNames.forEach((name) => {
+          const isLazy = node.getAttribute(lazyAttr) === 'lazy';
+          if (isLazy) {
+            const observerSettings = { rootMargin: '50px 0px', threshold: 0.01 };
+            const observer = new IntersectionObserver((entries) => {
+              entries.forEach((entry) => {
+                if (entry.intersectionRatio > 0) {
+                  observer.unobserve(node);
+                  factory(name, node, initAttr);
+                }
+              });
+            }, observerSettings);
+
+            observer.observe(node);
+            return null;
+          }
+          return factory(name, node, initAttr);
+        });
       }
     })
   );


### PR DESCRIPTION
Refactor: Move observer out of factory to optimize its usage

## Description

Adjusts observer placement to prevent per-component creation/destruction, keeping it only where needed.

## Related Issue

Fixes #9 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.mnd)** document.
- [X] All new and existing tests passed.
